### PR TITLE
Centralized the protocol, host and port

### DIFF
--- a/client/src/services/auth.service.js
+++ b/client/src/services/auth.service.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { host } from './server';
 
-const API_URL = 'http://' + host + '/api/auth/';
+const API_URL = host + '/api/auth/';
 
 class AuthService {
   login(user) {

--- a/client/src/services/auth.service.js
+++ b/client/src/services/auth.service.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
+import { host } from './server';
 
-const API_URL = 'http://localhost:9000/api/auth/';
+const API_URL = 'http://' + host + ':9000/api/auth/';
 
 class AuthService {
   login(user) {

--- a/client/src/services/auth.service.js
+++ b/client/src/services/auth.service.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { host } from './server';
 
-const API_URL = 'http://' + host + ':9000/api/auth/';
+const API_URL = 'http://' + host + '/api/auth/';
 
 class AuthService {
   login(user) {

--- a/client/src/services/calendar.service.js
+++ b/client/src/services/calendar.service.js
@@ -1,7 +1,8 @@
 import axios from 'axios'
 import authHeader from './auth-header';
+import { host } from './server';
 
-const SERVER_URL = 'http://localhost:9000/api/calendarevents/';
+const SERVER_URL = 'http://' + host + ':9000/api/calendarevents/';
 
 
 class CalendarService {

--- a/client/src/services/calendar.service.js
+++ b/client/src/services/calendar.service.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 import authHeader from './auth-header';
 import { host } from './server';
 
-const SERVER_URL = 'http://' + host + '/api/calendarevents/';
+const SERVER_URL = host + '/api/calendarevents/';
 
 
 class CalendarService {

--- a/client/src/services/calendar.service.js
+++ b/client/src/services/calendar.service.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 import authHeader from './auth-header';
 import { host } from './server';
 
-const SERVER_URL = 'http://' + host + ':9000/api/calendarevents/';
+const SERVER_URL = 'http://' + host + '/api/calendarevents/';
 
 
 class CalendarService {

--- a/client/src/services/server.js
+++ b/client/src/services/server.js
@@ -1,2 +1,2 @@
-let host = 'localhost';
+let host = 'localhost:9000';
 export { host };

--- a/client/src/services/server.js
+++ b/client/src/services/server.js
@@ -1,2 +1,2 @@
-let host = 'localhost:9000';
+let host = 'http://localhost:9000';
 export { host };

--- a/client/src/services/server.js
+++ b/client/src/services/server.js
@@ -1,0 +1,2 @@
+let host = 'localhost';
+export { host };

--- a/client/src/services/user.service.js
+++ b/client/src/services/user.service.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import authHeader from './auth-header';
 import { host } from './server';
 
-const SERVER_URL = 'http://' + host + '/api/users/';
+const SERVER_URL = host + '/api/users/';
 
 class UserService {
   getAll() {

--- a/client/src/services/user.service.js
+++ b/client/src/services/user.service.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
 import authHeader from './auth-header';
+import { host } from './server';
 
-const SERVER_URL = 'http://localhost:9000/api/users/';
+const SERVER_URL = 'http://' + host + ':9000/api/users/';
 
 class UserService {
   getAll() {

--- a/client/src/services/user.service.js
+++ b/client/src/services/user.service.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import authHeader from './auth-header';
 import { host } from './server';
 
-const SERVER_URL = 'http://' + host + ':9000/api/users/';
+const SERVER_URL = 'http://' + host + '/api/users/';
 
 class UserService {
   getAll() {


### PR DESCRIPTION
In order to make the Katacoda simple to follow, I had to put the port for everything in a single location, so I created a single file, exported that as a variable, use that variable in creating the URLs and gave instructions in the Katacoda on how to change that variable.